### PR TITLE
Remove test_spec section from the podspec-file

### DIFF
--- a/TinkMoneyManagerUI.podspec
+++ b/TinkMoneyManagerUI.podspec
@@ -13,10 +13,5 @@ Pod::Spec.new do |spec|
 
   spec.swift_version = ["5.1", "5.2", "5.3"]
 
-  spec.test_spec "Tests" do |test_spec|
-    test_spec.source_files = "Tests/**/*.swift"
-    test_spec.dependency "SnapshotTesting", "~> 1.7"
-  end
-
   spec.dependency "TinkCore", "~> 1.5.3"
 end


### PR DESCRIPTION
Remove unnecessary `test_spec` section from the `podspec` configuration file used by Cocoapods