### PR TITLE
Link podspec homepage to repo address

### DIFF
--- a/TinkMoneyManagerUI.podspec
+++ b/TinkMoneyManagerUI.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |spec|
   spec.version      = "0.27.1"
   spec.license      = { :type => "Tink", :file => "LICENSE" }
   spec.authors      = { "Tink AB" => "mobile@tink.se" }
-  spec.homepage     = "https://tink.com"
+  spec.homepage     = "https://github.com/tink-ab/tink-money-manager-ios"
   spec.summary      = "Tink Money Manager UI SDK."
   spec.source       = { :git => "https://github.com/tink-ab/tink-money-manager-ios.git", :tag => spec.version }
 


### PR DESCRIPTION
Update podspec homepage link according to guide [Podspec Syntax Reference](https://guides.cocoapods.org/syntax/podspec.html)